### PR TITLE
build2024/update pyversion

### DIFF
--- a/notebooks/01-embeddings.ipynb
+++ b/notebooks/01-embeddings.ipynb
@@ -26,7 +26,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec(\"movie_buddy\"):\n",
-    "    !pip install git+https:https://github.com/xtreamsrl/movies-buddy"
+    "    !pip install git+https://github.com/xtreamsrl/movies-buddy"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Your AI-powered movie buddy"
 authors = [
     {name = "baggiponte", email = "57922983+baggiponte@users.noreply.github.com"},
 ]
-requires-python = "==3.11.*"
+requires-python = "==3.10.*"
 readme = "README.md"
 license = {text = "MIT"}
 dependencies = [


### PR DESCRIPTION
- Use Py 3.10 to ensure it's installed on Colab
- remove double https